### PR TITLE
refactor: website rename, docs follow suit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Digital Rocks Docs
+# Digital Porous Media Portal
 
-Digital Rocks documentation for [digitalrocksportal.org](https://digitalrocksportal.org).
+Documentation for [digitalporousmedia.org](https://digitalporousmedia.org/).
 
 ## Contributing
 

--- a/docs/about_us.md
+++ b/docs/about_us.md
@@ -2,13 +2,13 @@
 
 ## Our Mission and Overview
 
-Launched in 2015, the Digital Porous Media Portal (DRP) serves as a vital open repository for the geosciences and engineering communities focused on porous materials. Our mission is multi-faceted:
+Launched in 2015, the Digital Porous Media Portal (DPM) serves as a vital open repository for the geosciences and engineering communities focused on porous materials. Our mission is multi-faceted:
 
 * **Organize and Preserve:** We provide a robust platform to securely store, organize, and preserve valuable imaged datasets and related experimental measurements of porous materials, primarily focusing on subsurface media like rocks and soil.
 * **Connect and Analyze:** We strive to link these datasets with simulation, analysis, and visualization tools, thereby enhancing their scientific utility and enabling deeper insights.
 * **Educate and Collaborate:** We are committed to supporting the research community by offering educational resources, organizing workshops and challenges, and fostering collaboration through data sharing.
 
-Understanding the complex processes of flow, transport, and deformation within porous media is fundamental to addressing critical challenges in environmental science, civil engineering, petroleum engineering, and basic geology. The DRP aims to accelerate research and education in these important fields by providing access to high-quality data.
+Understanding the complex processes of flow, transport, and deformation within porous media is fundamental to addressing critical challenges in environmental science, civil engineering, petroleum engineering, and basic geology. The DPM aims to accelerate research and education in these important fields by providing access to high-quality data.
 
 ## Scope and Content Policy
 
@@ -37,7 +37,7 @@ We gratefully acknowledge the foundational work and significant contributions of
 
 ## Connections and Community Engagement
 
-DRP is proud to be an active participant in the broader research data ecosystem:
+DPM is proud to be an active participant in the broader research data ecosystem:
 
 * An affiliated project within **EarthCube**, enhancing access to geoscience data.
 * A member of the **EarthCube Council of Data Facilities**.
@@ -46,7 +46,7 @@ DRP is proud to be an active participant in the broader research data ecosystem:
 
 ## News Highlights
 
-Keep up with DRP developments and recognition:
+Keep up with DPM developments and recognition:
 
 * [Digital Porous Media Physics Helps Scientists Understand Porous Media (TACC, Feb 2017)](https://www.pge.utexas.edu/news/350-tacc-digital-rocks-portal) 
 * Featured in the Journal of Petroleum Technology (Apr 2016)
@@ -59,7 +59,7 @@ The Digital Porous Media Portal is currently supported by a grant from the **Nat
 
 Initial development was made possible through generous funding from NSF EAR CAREER Grant 1255622 and NSF EarthCube Grant 1541008 (2015-2018). Additional support has been provided through the industry affiliate program led by Dr. Prodanovic.
 
-To ensure the long-term viability and continued service to the community, the DRP transitioned to a community-supported funding model in September 2021. Details regarding membership options and data storage fees can be found in the [User Agreement](user_agreement.md).
+To ensure the long-term viability and continued service to the community, the DPM transitioned to a community-supported funding model in September 2021. Details regarding membership options and data storage fees can be found in the [User Agreement](user_agreement.md).
 
 We sincerely thank all funding agencies, institutional partners, and community supporters who make the Digital Porous Media Portal possible.
 

--- a/docs/about_us.md
+++ b/docs/about_us.md
@@ -1,8 +1,8 @@
-# About the Digital Rocks Portal
+# About the Digital Porous Media Portal
 
 ## Our Mission and Overview
 
-Launched in 2015, the Digital Rocks Portal (DRP) serves as a vital open repository for the geosciences and engineering communities focused on porous materials. Our mission is multi-faceted:
+Launched in 2015, the Digital Porous Media Portal (DRP) serves as a vital open repository for the geosciences and engineering communities focused on porous materials. Our mission is multi-faceted:
 
 * **Organize and Preserve:** We provide a robust platform to securely store, organize, and preserve valuable imaged datasets and related experimental measurements of porous materials, primarily focusing on subsurface media like rocks and soil.
 * **Connect and Analyze:** We strive to link these datasets with simulation, analysis, and visualization tools, thereby enhancing their scientific utility and enabling deeper insights.
@@ -12,7 +12,7 @@ Understanding the complex processes of flow, transport, and deformation within p
 
 ## Scope and Content Policy
 
-The Digital Rocks Portal is specifically designed to host datasets pertinent to the study of porous materials. This includes, but is not limited to:
+The Digital Porous Media Portal is specifically designed to host datasets pertinent to the study of porous materials. This includes, but is not limited to:
 
 * 2D and 3D images (e.g., from X-ray CT, micro-CT, FIB-SEM, SEM)
 * Associated experimental data (e.g., core analysis, petrophysical measurements)
@@ -22,7 +22,7 @@ The Digital Rocks Portal is specifically designed to host datasets pertinent to 
 
 ## Our Team
 
-The Digital Rocks Portal initiative is led by **Dr. Maša Prodanović**, faculty in the Hildebrand Department of Petroleum and Geosystems Engineering at The University of Texas at Austin.
+The Digital Porous Media Portal initiative is led by **Dr. Maša Prodanović**, faculty in the Hildebrand Department of Petroleum and Geosystems Engineering at The University of Texas at Austin.
 
 The portal leverages the significant capabilities of the **Texas Advanced Computing Center (TACC)** for high-performance storage, computing resources, and technical expertise, supported by the **University of Texas System Research Cyberinfrastructure (UTRC)** initiative. Administrative support is provided by the Center for Subsurface Energy and the Environment at UT Austin.
 
@@ -48,20 +48,20 @@ DRP is proud to be an active participant in the broader research data ecosystem:
 
 Keep up with DRP developments and recognition:
 
-* [Digital Rocks Physics Helps Scientists Understand Porous Media (TACC, Feb 2017)](https://www.pge.utexas.edu/news/350-tacc-digital-rocks-portal) 
+* [Digital Porous Media Physics Helps Scientists Understand Porous Media (TACC, Feb 2017)](https://www.pge.utexas.edu/news/350-tacc-digital-rocks-portal) 
 * Featured in the Journal of Petroleum Technology (Apr 2016)
 * Spotlighted by InterPore (May 2016)
 * [Subscribe to our Newsletter](link-to-newsletter-signup) *(Placeholder for actual link)* for the latest news, dataset highlights, and event announcements.
 
 ## Funding and Sustainability
 
-The Digital Rocks Portal is currently supported by a grant from the **National Science Foundation (NSF GEO OSE 2324786)**.
+The Digital Porous Media Portal is currently supported by a grant from the **National Science Foundation (NSF GEO OSE 2324786)**.
 
 Initial development was made possible through generous funding from NSF EAR CAREER Grant 1255622 and NSF EarthCube Grant 1541008 (2015-2018). Additional support has been provided through the industry affiliate program led by Dr. Prodanovic.
 
 To ensure the long-term viability and continued service to the community, the DRP transitioned to a community-supported funding model in September 2021. Details regarding membership options and data storage fees can be found in the [User Agreement](user_agreement.md).
 
-We sincerely thank all funding agencies, institutional partners, and community supporters who make the Digital Rocks Portal possible.
+We sincerely thank all funding agencies, institutional partners, and community supporters who make the Digital Porous Media Portal possible.
 
 ## Get Involved
 

--- a/docs/about_us.md
+++ b/docs/about_us.md
@@ -48,7 +48,7 @@ DPM is proud to be an active participant in the broader research data ecosystem:
 
 Keep up with DPM developments and recognition:
 
-* [Digital Porous Media Physics Helps Scientists Understand Porous Media (TACC, Feb 2017)](https://www.pge.utexas.edu/news/350-tacc-digital-rocks-portal) 
+* [Digital Rocks Portal Physics Helps Scientists Understand Porous Media (TACC, Feb 2017)](https://www.pge.utexas.edu/news/350-tacc-digital-rocks-portal) 
 * Featured in the Journal of Petroleum Technology (Apr 2016)
 * Spotlighted by InterPore (May 2016)
 * [Subscribe to our Newsletter](link-to-newsletter-signup) *(Placeholder for actual link)* for the latest news, dataset highlights, and event announcements.

--- a/docs/cite_dataset.md
+++ b/docs/cite_dataset.md
@@ -1,10 +1,10 @@
 # How to Cite a Dataset from the Portal
 
-Properly citing datasets you retrieve and use from the Digital Porous Media Portal (DRP) is essential for giving appropriate credit to the data creators and ensuring the transparency and reproducibility of research.
+Properly citing datasets you retrieve and use from the Digital Porous Media Portal (DPM) is essential for giving appropriate credit to the data creators and ensuring the transparency and reproducibility of research.
 
 ## Using the Dataset DOI
 
-Published datasets within the DRP are assigned a persistent **Digital Object Identifier (DOI)**. This DOI ensures the dataset can be reliably located and referenced over time, even if its web address changes.
+Published datasets within the DPM are assigned a persistent **Digital Object Identifier (DOI)**. This DOI ensures the dataset can be reliably located and referenced over time, even if its web address changes.
 
 * **Find the DOI:** You should find the specific DOI prominently displayed on the landing page or metadata record for the dataset you are using within the portal.
 * **Include in Citation:** When citing the dataset, please include standard bibliographic information along with the DOI. Key elements are typically:

--- a/docs/cite_dataset.md
+++ b/docs/cite_dataset.md
@@ -1,6 +1,6 @@
 # How to Cite a Dataset from the Portal
 
-Properly citing datasets you retrieve and use from the Digital Rocks Portal (DRP) is essential for giving appropriate credit to the data creators and ensuring the transparency and reproducibility of research.
+Properly citing datasets you retrieve and use from the Digital Porous Media Portal (DRP) is essential for giving appropriate credit to the data creators and ensuring the transparency and reproducibility of research.
 
 ## Using the Dataset DOI
 
@@ -11,12 +11,12 @@ Published datasets within the DRP are assigned a persistent **Digital Object Ide
     * Author(s) of the dataset
     * Year of publication on the portal
     * Title of the dataset
-    * Publisher: Digital Rocks Portal
+    * Publisher: Digital Porous Media Portal
     * The unique DOI (usually presented as a hyperlink, e.g., `http://dx.doi.org/...`)
 
 The exact format will depend on the citation style guide required by your publisher or institution (e.g., APA, MLA, Chicago, Vancouver), but ensure these core elements, especially the DOI, are included. The portal utilizes the DataCite metadata schema to help structure the information needed for proper citation.
 
 ## Also Cite the Portal Platform
 
-In addition to citing the specific dataset(s), please also cite the Digital Rocks Portal platform itself, as it is the source repository. Refer to the [How to Cite the Digital Rocks Portal](cite_us.md) page for the correct citation format.
+In addition to citing the specific dataset(s), please also cite the Digital Porous Media Portal platform itself, as it is the source repository. Refer to the [How to Cite the Digital Porous Media Portal](cite_us.md) page for the correct citation format.
 

--- a/docs/cite_us.md
+++ b/docs/cite_us.md
@@ -1,10 +1,10 @@
-# How to Cite the Digital Rocks Portal
+# How to Cite the Digital Porous Media Portal
 
-If you use the Digital Rocks Portal (DRP) platform or data hosted on it in your research, publications, presentations, or other work, we request that you include the following citations to acknowledge the portal resource:
+If you use the Digital Porous Media Portal (DRP) platform or data hosted on it in your research, publications, presentations, or other work, we request that you include the following citations to acknowledge the portal resource:
 
 > Masa Prodanovic, Maria Esteva, Matthew Hanlon, Gaurav Nanda, Prateek Agarwal (2015) Digital Porous Media Portal: a repository for porous media images http://dx.doi.org/10.17612/P7CC7K
 
-> Turhan, Çınar, Bernard Chang, Ali Mohamed, Maria Esteva, Richard Ketcham, James McClure, and Masa Prodanovic. “Digital Rocks Portal for Image Curation, Characterization, Visualization, and Transport Simulation in Porous Media.” In International Symposium of the Society of Core Analysts. SCA2024-1056, 2024.
+> Turhan, Çınar, Bernard Chang, Ali Mohamed, Maria Esteva, Richard Ketcham, James McClure, and Masa Prodanovic. “Digital Porous Media Portal for Image Curation, Characterization, Visualization, and Transport Simulation in Porous Media.” In International Symposium of the Society of Core Analysts. SCA2024-1056, 2024.
 
 
 Using this citation helps recognize the effort involved in developing and maintaining this valuable community resource.

--- a/docs/cite_us.md
+++ b/docs/cite_us.md
@@ -1,6 +1,6 @@
 # How to Cite the Digital Porous Media Portal
 
-If you use the Digital Porous Media Portal (DRP) platform or data hosted on it in your research, publications, presentations, or other work, we request that you include the following citations to acknowledge the portal resource:
+If you use the Digital Porous Media Portal (DPM) platform or data hosted on it in your research, publications, presentations, or other work, we request that you include the following citations to acknowledge the portal resource:
 
 > Masa Prodanovic, Maria Esteva, Matthew Hanlon, Gaurav Nanda, Prateek Agarwal (2015) Digital Porous Media Portal: a repository for porous media images http://dx.doi.org/10.17612/P7CC7K
 

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -7,3 +7,8 @@ footer {
 [data-page-name="index.md"] .wy-nav-content {
   padding-bottom: 0; /* to undo ReadTheDocs theme.css */
 }
+
+/* to overwrite svg height attribute */
+.logo svg {
+  height: auto;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
-# Digital Rocks Documentation
+# Digital Porous Media Documentation
 
-Welcome to the Digital Rocks documentation. This documentation provides comprehensive information about the Digital Rocks Portal, its features, and how to use them effectively.
+Welcome to the Digital Porous Media documentation. This documentation provides comprehensive information about the Digital Porous Media Portal, its features, and how to use them effectively.
 
 ## Overview
 
-The Digital Rocks Portal is a platform for sharing, visualizing, and analyzing digital rock data. This documentation will help you understand:
+The Digital Porous Media Portal is a platform for sharing, visualizing, and analyzing digital rock data. This documentation will help you understand:
 
 - How to use the portal effectively
 - Available features and capabilities
@@ -13,7 +13,7 @@ The Digital Rocks Portal is a platform for sharing, visualizing, and analyzing d
 
 ## Getting Started
 
-To get started with Digital Rocks:
+To get started with Digital Porous Media:
 
 1. Visit [digitalrocksportal.org](https://digitalrocksportal.org)
 2. Create an account or sign in
@@ -24,7 +24,7 @@ To get started with Digital Rocks:
 
 This documentation is organized into several sections:
 
-- **Digital Rocks Essentials**: Core documentation and usage guides
+- **Digital Porous Media Essentials**: Core documentation and usage guides
 - **Advanced Topics**: Detailed information about specific features and capabilities
 - **API Reference**: Technical documentation for developers
 - **Tutorials**: Step-by-step guides for common tasks

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ The Digital Porous Media Portal is a platform for sharing, visualizing, and anal
 
 To get started with Digital Porous Media:
 
-1. Visit [digitalrocksportal.org](https://digitalrocksportal.org)
+1. Visit [digitalporousmedia.org](https://digitalporousmedia.org)
 2. Create an account or sign in
 3. Explore the available datasets and tools
 4. Start sharing your own digital rock data
@@ -33,6 +33,6 @@ This documentation is organized into several sections:
 
 If you need assistance or have questions:
 
-- Check our [FAQ section](https://digitalrocksportal.org/faq)
-- Contact our support team at [support@digitalrocksportal.org](mailto:support@digitalrocksportal.org)
+- Check our [FAQ section](https://digitalporousmedia.org/faq)
+- Contact our support team at [support@digitalporousmedia.org](mailto:support@digitalporousmedia.org)
 - Join our community forum 

--- a/docs/some-page copy.md
+++ b/docs/some-page copy.md
@@ -1,6 +1,6 @@
 # Some Page
 
-This is a sample page in the Digital Rocks documentation. You can use this as a template for creating additional documentation pages.
+This is a sample page in the Digital Porous Media documentation. You can use this as a template for creating additional documentation pages.
 
 ## Section 1
 

--- a/docs/some-page copy.md
+++ b/docs/some-page copy.md
@@ -1,6 +1,6 @@
 # Some Page
 
-This is a sample page in the Digital Porous Media documentation. You can use this as a template for creating additional documentation pages.
+This is a sample page in the Digital Porous Media Portal documentation. You can use this as a template for creating additional documentation pages.
 
 ## Section 1
 

--- a/docs/some-page.md
+++ b/docs/some-page.md
@@ -1,6 +1,6 @@
 # Some Page
 
-This is a sample page in the Digital Rocks documentation. You can use this as a template for creating additional documentation pages.
+This is a sample page in the Digital Porous Media documentation. You can use this as a template for creating additional documentation pages.
 
 ## Section 1
 

--- a/docs/some-page.md
+++ b/docs/some-page.md
@@ -1,6 +1,6 @@
 # Some Page
 
-This is a sample page in the Digital Porous Media documentation. You can use this as a template for creating additional documentation pages.
+This is a sample page in the Digital Porous Media Portal documentation. You can use this as a template for creating additional documentation pages.
 
 ## Section 1
 

--- a/docs/upload_data.md
+++ b/docs/upload_data.md
@@ -1,13 +1,13 @@
 # How to Upload Data: A Step-by-Step Guide
 
-This guide provides step-by-step instructions for uploading your porous media datasets to the Digital Porous Media Portal (DRP). Following these steps helps ensure your data is well-described, discoverable, and usable by the community.
+This guide provides step-by-step instructions for uploading your porous media datasets to the Digital Porous Media Portal (DPM). Following these steps helps ensure your data is well-described, discoverable, and usable by the community.
 
 **Before You Begin:**
 
-* **Account:** Ensure you have registered for a TACC account at [https://accounts.tacc.utexas.edu/register](https://accounts.tacc.utexas.edu/register) and are logged into the DRP.
+* **Account:** Ensure you have registered for a TACC account at [https://accounts.tacc.utexas.edu/register](https://accounts.tacc.utexas.edu/register) and are logged into the DPM.
 * **Data Organization:** Plan the structure of your data. Consider distinguishing between originating raw data and derived analysis data. It's often helpful to organize your files and folders locally on your computer or cloud storage (like Dropbox/UT Box) *before* uploading.
 * **File Size:**
-    * If your total dataset **exceeds 2GB**, please **email the DRP staff first** to discuss the upload.
+    * If your total dataset **exceeds 2GB**, please **email the DPM staff first** to discuss the upload.
     * Consider splitting very large volumetric files into smaller, manageable chunks (e.g., under 2GB each) before uploading. This aids users with downloading and processing the data later.
 * **Compression:** **Avoid compressing** individual image files (e.g., into `.zip` or `.tar.gz` archives) before uploading if possible. Uploading raw or standard image formats directly allows the portal to automatically generate previews (like GIF movies) and perform basic analysis (like histograms). Use the portal's bulk upload options (Dropbox, UTBox) for transferring many files or large files efficiently.
 
@@ -15,9 +15,9 @@ This guide provides step-by-step instructions for uploading your porous media da
 
 **Step 1: Create or Select a Project**
 
-All data on DRP belongs to a "Project".
+All data on DPM belongs to a "Project".
 
-1.  Log in to the DRP and navigate to the **"My Projects"** interface.
+1.  Log in to the DPM and navigate to the **"My Projects"** interface.
 2.  Choose one:
     * **Create a New Project:** Click the option to create a new project. Provide a descriptive name.
         * *Note on Ownership:* For citation purposes, it's best if the primary data author is the project owner. If someone else (e.g., a student or assistant) will be uploading the data, the data owner should ideally create the project and then add the uploader as a collaborator (see Step 2).
@@ -27,9 +27,9 @@ All data on DRP belongs to a "Project".
 
 If members of your team need to help manage the project or view the data while it's still private:
 
-1.  Ensure your collaborators are registered users on the DRP.
+1.  Ensure your collaborators are registered users on the DPM.
 2.  Within your project's management interface, find the option to add collaborators.
-3.  Add them using their registered DRP/TACC username or email. Collaborators can then edit the project and upload data.
+3.  Add them using their registered DPM/TACC username or email. Collaborators can then edit the project and upload data.
 
 **Step 3: Upload Your Data Files**
 
@@ -46,8 +46,8 @@ Metadata (data about your data) is essential for making your dataset understanda
 
 1.  **Project Description:** Provide a clear description of the overall project, the physical sample(s), and the experiment(s) involved. Link to relevant publications if available.
 2.  **File-Level Metadata:** For each uploaded data file (especially images), provide necessary details.
-3.  **Minimum Requirements:** The DRP enforces minimum metadata standards. Pay attention to warnings indicating missing required information. The more detail you provide, the more valuable your dataset becomes.
-4.  **Critical Metadata for Raw Binary Images:** Raw binary files (`.raw`, `.bin`, etc.) do not contain size or format information internally. To allow DRP to display them correctly, you **must** provide:
+3.  **Minimum Requirements:** The DPM enforces minimum metadata standards. Pay attention to warnings indicating missing required information. The more detail you provide, the more valuable your dataset becomes.
+4.  **Critical Metadata for Raw Binary Images:** Raw binary files (`.raw`, `.bin`, etc.) do not contain size or format information internally. To allow DPM to display them correctly, you **must** provide:
     * **Voxel Dimensions:** The number of voxels (pixels in 3D) in each direction (e.g., width, height, depth/slices).
     * **Voxel Size:** The physical size of one voxel (e.g., in µm). If not applicable (e.g., for synthetic data), enter '1' and make a note in the description.
     * **Data Type:** The numerical format (e.g., 8-bit unsigned integer, 16-bit signed integer, 32-bit float).
@@ -76,4 +76,4 @@ Your uploaded data is now stored **privately** within your project.
 
 ---
 
-For further details on specific file formats or metadata fields, please refer to the relevant sections of the documentation. If you encounter issues, contact the DRP support team.
+For further details on specific file formats or metadata fields, please refer to the relevant sections of the documentation. If you encounter issues, contact the DPM support team.

--- a/docs/upload_data.md
+++ b/docs/upload_data.md
@@ -1,6 +1,6 @@
 # How to Upload Data: A Step-by-Step Guide
 
-This guide provides step-by-step instructions for uploading your porous media datasets to the Digital Rocks Portal (DRP). Following these steps helps ensure your data is well-described, discoverable, and usable by the community.
+This guide provides step-by-step instructions for uploading your porous media datasets to the Digital Porous Media Portal (DRP). Following these steps helps ensure your data is well-described, discoverable, and usable by the community.
 
 **Before You Begin:**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ edit_uri: edit/main/docs/
 theme:
   name: tacc_readthedocs
   # "ReadTheDocs" Theme Features
-  logo: https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@5717c8d/digitalrocks_assets/NSF-DigitalRocks-Logo.svg
+  logo: https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@621b441/digitalrocks_assets/logo.svg
   # "TACC" Theme Features
   portal_url: https://digitalporousmedia.org
   portal_name: digitalporousmedia.org

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Digital Porous Media Documentation
 site_description: Digital Porous Media Technical Documentation
 site_author: Digital Porous Media Team
-site_url: https://digitalrocksportal.org
+site_url: https://digitalporousmedia.org
 repo_url: https://github.com/digital-porous-media/dpm_docs
 edit_uri: edit/main/docs/
 
@@ -10,8 +10,8 @@ theme:
   # "ReadTheDocs" Theme Features
   logo: https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@5717c8d/digitalrocks_assets/NSF-DigitalRocks-Logo.svg
   # "TACC" Theme Features
-  portal_url: https://digitalrocksportal.org
-  portal_name: digitalrocksportal.org
+  portal_url: https://digitalporousmedia.org
+  portal_name: digitalporousmedia.org
 
 extra_css:
   - css/extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ edit_uri: edit/main/docs/
 theme:
   name: tacc_readthedocs
   # "ReadTheDocs" Theme Features
-  logo: https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@621b441/digitalrocks_assets/logo.svg
+  logo: https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@621b441/digitalrocks_assets/logo/logo--black.svg
   # "TACC" Theme Features
   portal_url: https://digitalporousmedia.org
   portal_name: digitalporousmedia.org

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: Digital Porous Media Documentation
-site_description: Digital Porous Media Technical Documentation
-site_author: Digital Porous Media Team
+site_name: Digital Porous Media Portal Documentation
+site_description: Documentation for Digital Porous Media Portal
+site_author: Digital Porous Media Portal Team
 site_url: https://digitalporousmedia.org
 repo_url: https://github.com/digital-porous-media/dpm_docs
 edit_uri: edit/main/docs/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: Digital Rocks Documentation
-site_description: Digital Rocks Technical Documentation
-site_author: Digital Rocks Team
+site_name: Digital Porous Media Documentation
+site_description: Digital Porous Media Technical Documentation
+site_author: Digital Porous Media Team
 site_url: https://digitalrocksportal.org
 repo_url: https://github.com/digital-porous-media/dpm_docs
 edit_uri: edit/main/docs/
@@ -34,7 +34,7 @@ markdown_extensions:
 
 # add contents from agu presentations
 nav:
-  - Digital Rocks Essentials:
+  - Digital Porous Media Essentials:
     - Documentation Overview: index.md
     - About Us: about_us.md
     - Cite Us: cite_us.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["poetry-core>=1.5.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [project]
-name = "digital-rocks-docs"
+name = "dpm_docs"
 version = "0.1.0"
-description = "Digital Porous Media Documentation"
+description = "Documentation for Digital Porous Media Portal"
 authors = [
   { name = "TACC COA CMD", email = "coa-cmd@tacc.utexas.edu" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [project]
 name = "digital-rocks-docs"
 version = "0.1.0"
-description = "Digital Rocks Documentation"
+description = "Digital Porous Media Documentation"
 authors = [
   { name = "TACC COA CMD", email = "coa-cmd@tacc.utexas.edu" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,5 @@ dependencies = [
 ]
 
 [project.urls]
-homepage = "https://digitalrocksportal.org"
+homepage = "https://digitalporousmedia.org"
 github = "https://github.com/wesleyboar/Digital-Rocks-Docs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.5.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [project]
-name = "dpm_docs"
+name = "dpm-docs"
 version = "0.1.0"
 description = "Documentation for Digital Porous Media Portal"
 authors = [


### PR DESCRIPTION
## Overview

Website is renamed. URL is changed. Updating docs.

## Changes

| Before | After |
| - | - |
| https://www.digitalrocksportal.org/ | https://digitalporousmedia.org/ |
| Digital Rocks Portal | Digital Porous Media Portal |
| DRP | DPM |
| Digital Porous Media … | Digital Porous Media Portal … |
| `digital_rocks_docs` | `dpm_docs` |

Also, updated logo (and constrained its size).

## Testing

1. Follow [TACC's MkDocs "Testing: Test Locally" instructions](https://tacc.github.io/mkdocs-tacc/test/#test-locally).
2. Open http://127.0.0.1:8000/.
3. Search page for "rocks".
4. See no results.
5. [Search docs for "rocks".](http://127.0.0.1:8000/search.html?q=rocks)
6. See only one reference, historical.
7. Also, see logo is updated.

## UI

| Index | Site |
| - | - |
| <img width="960" alt="index" src="https://github.com/user-attachments/assets/113441f7-7643-4f5f-a319-e8f2180677b5" /> | <img width="960" alt="site" src="https://github.com/user-attachments/assets/cc371991-0911-45fa-ae41-290330d070cc" /> |

| Logo |
| - |
| <img width="326" alt="logo" src="https://github.com/user-attachments/assets/3871d17f-9454-4133-8bb2-07e7fc606bb6" /> |