### PR TITLE
fix: remove unavailable sources of help

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,5 +37,3 @@ This documentation is organized into several sections:
 If you need assistance or have questions:
 
 - Check our [FAQ section](https://digitalporousmedia.org/faq)
-- Contact our support team at [support@digitalporousmedia.org](mailto:support@digitalporousmedia.org)
-- Join our community forum 


### PR DESCRIPTION
The e-mail address is not monitored. TACC staff investigates, but stakeholder (M.P.) says she does not know of any e-mail that they ever used.

The community forum has no link, so I remove it.

<details><summary>Thoughts</summary>

I think the `index.md` was originally something had A.I. generate. I expected DPM team to review and update the content before relying on it; maybe the comments about it now are the review.

</details>